### PR TITLE
[Feature] player secondary action

### DIFF
--- a/Moonlighter/Assets/Animations/Will/Player AC.controller
+++ b/Moonlighter/Assets/Animations/Will/Player AC.controller
@@ -79,7 +79,8 @@ AnimatorState:
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: 4871288828298072823}
-  m_StateMachineBehaviours: []
+  m_StateMachineBehaviours:
+  - {fileID: 6356763487085963279}
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
   m_WriteDefaultValues: 1
@@ -477,7 +478,8 @@ AnimatorState:
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: -815147475787736522}
-  m_StateMachineBehaviours: []
+  m_StateMachineBehaviours:
+  - {fileID: -2015401306633965994}
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
   m_WriteDefaultValues: 1
@@ -579,6 +581,18 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!114 &-2015401306633965994
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 70daf7764ba91b840bd06a2f6188eb73, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1101 &-1556585736229171819
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -964,7 +978,8 @@ AnimatorState:
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: -2027725239465236810}
-  m_StateMachineBehaviours: []
+  m_StateMachineBehaviours:
+  - {fileID: 5468198412160847733}
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
   m_WriteDefaultValues: 1
@@ -1186,6 +1201,18 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!114 &5468198412160847733
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bcd48fa099bbb9a4abbc285035298c6b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &5786148398239161841
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -1285,6 +1312,18 @@ BlendTree:
   m_UseAutomaticThresholds: 1
   m_NormalizedBlendValues: 0
   m_BlendType: 1
+--- !u!114 &6356763487085963279
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 229a6e9becbebbe419d100bc051dafed, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1109 &7651364687684460275
 AnimatorTransition:
   m_ObjectHideFlags: 1

--- a/Moonlighter/Assets/Animations/Will/Player AC.controller
+++ b/Moonlighter/Assets/Animations/Will/Player AC.controller
@@ -744,7 +744,7 @@ AnimatorStateTransition:
   m_TransitionDuration: 0
   m_TransitionOffset: 0
   m_ExitTime: 1
-  m_HasExitTime: 1
+  m_HasExitTime: 0
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
@@ -850,67 +850,67 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: MoveY
     m_Type: 1
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Idle
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Move
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Roll
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: ComboAttackOne
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: ComboAttackTwo
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: ComboAttackThree
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: ReadySecondaryAction
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: OnSecondaryAction
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: SecondaryAction
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer

--- a/Moonlighter/Assets/Animations/Will/Shield/Down/Will_ReadyShieldSecondaryAction_Down.anim
+++ b/Moonlighter/Assets/Animations/Will/Shield/Down/Will_ReadyShieldSecondaryAction_Down.anim
@@ -66,7 +66,7 @@ AnimationClip:
     m_Level: 0
     m_CycleOffset: 0
     m_HasAdditiveReferencePose: 0
-    m_LoopTime: 1
+    m_LoopTime: 0
     m_LoopBlend: 0
     m_LoopBlendOrientation: 0
     m_LoopBlendPositionY: 0

--- a/Moonlighter/Assets/Animations/Will/Shield/Left/Will_ReadyShieldSecondaryAction_Left.anim
+++ b/Moonlighter/Assets/Animations/Will/Shield/Left/Will_ReadyShieldSecondaryAction_Left.anim
@@ -66,7 +66,7 @@ AnimationClip:
     m_Level: 0
     m_CycleOffset: 0
     m_HasAdditiveReferencePose: 0
-    m_LoopTime: 1
+    m_LoopTime: 0
     m_LoopBlend: 0
     m_LoopBlendOrientation: 0
     m_LoopBlendPositionY: 0

--- a/Moonlighter/Assets/Animations/Will/Shield/Right/Will_ReadyShieldSecondaryAction_Right.anim
+++ b/Moonlighter/Assets/Animations/Will/Shield/Right/Will_ReadyShieldSecondaryAction_Right.anim
@@ -66,7 +66,7 @@ AnimationClip:
     m_Level: 0
     m_CycleOffset: 0
     m_HasAdditiveReferencePose: 0
-    m_LoopTime: 1
+    m_LoopTime: 0
     m_LoopBlend: 0
     m_LoopBlendOrientation: 0
     m_LoopBlendPositionY: 0

--- a/Moonlighter/Assets/Animations/Will/Shield/Up/Will_ReadyShieldSecondaryAction_Up.anim
+++ b/Moonlighter/Assets/Animations/Will/Shield/Up/Will_ReadyShieldSecondaryAction_Up.anim
@@ -66,7 +66,7 @@ AnimationClip:
     m_Level: 0
     m_CycleOffset: 0
     m_HasAdditiveReferencePose: 0
-    m_LoopTime: 1
+    m_LoopTime: 0
     m_LoopBlend: 0
     m_LoopBlendOrientation: 0
     m_LoopBlendPositionY: 0

--- a/Moonlighter/Assets/InputActions/PlayerInput.inputactions
+++ b/Moonlighter/Assets/InputActions/PlayerInput.inputactions
@@ -31,6 +31,15 @@
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": false
+                },
+                {
+                    "name": "SecondaryAction",
+                    "type": "Button",
+                    "id": "bdf54075-fe58-4c3e-8635-fc445be6806d",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
                 }
             ],
             "bindings": [
@@ -108,6 +117,17 @@
                     "processors": "",
                     "groups": "PC",
                     "action": "ComboAttack",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "341505e9-280a-4008-9027-0c92f023dc33",
+                    "path": "<Keyboard>/k",
+                    "interactions": "Hold,Press",
+                    "processors": "",
+                    "groups": "PC",
+                    "action": "SecondaryAction",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }

--- a/Moonlighter/Assets/Scenes/SampleScene.unity
+++ b/Moonlighter/Assets/Scenes/SampleScene.unity
@@ -556,6 +556,22 @@ MonoBehaviour:
         m_CallState: 2
     m_ActionId: 22972b0b-3f5e-49f1-9903-89155d3acbe1
     m_ActionName: PlayerAction/ComboAttack[/Keyboard/j]
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1111704774}
+        m_TargetAssemblyTypeName: PlayerInputHandler, Assembly-CSharp
+        m_MethodName: OnSecondaryAction
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: bdf54075-fe58-4c3e-8635-fc445be6806d
+    m_ActionName: PlayerAction/SecondaryAction[/Keyboard/k]
   m_NeverAutoSwitchControlSchemes: 0
   m_DefaultControlScheme: 
   m_DefaultActionMap: PlayerAction

--- a/Moonlighter/Assets/Scripts/Player/Data/EnumValue.cs
+++ b/Moonlighter/Assets/Scripts/Player/Data/EnumValue.cs
@@ -7,6 +7,9 @@ namespace EnumValue
         Roll,
         ComboAttackOne,
         ComboAttackTwo,
-        ComboAttackThree
+        ComboAttackThree,
+        ReadySecondaryAction,
+        OnSecondaryAction,
+        SecondaryAction
     }
 }

--- a/Moonlighter/Assets/Scripts/Player/Data/PlayerAnimParams.cs
+++ b/Moonlighter/Assets/Scripts/Player/Data/PlayerAnimParams.cs
@@ -8,4 +8,7 @@ public static class PlayerAnimParams
     public const string COMBOATTACKONE = "ComboAttackOne";
     public const string COMBOATTACKTWO = "ComboAttackTwo";
     public const string COMBOATTACKTHREE = "ComboAttackThree";
+    public const string READYSECONDARYACTION = "ReadySecondaryAction";
+    public const string ONSECONDARYACTION = "OnSecondaryAction";
+    public const string SECONDARYACTION = "SecondaryAction";
 }

--- a/Moonlighter/Assets/Scripts/Player/Input/PlayerInputHandler.cs
+++ b/Moonlighter/Assets/Scripts/Player/Input/PlayerInputHandler.cs
@@ -9,6 +9,8 @@ public class PlayerInputHandler : MonoBehaviour
 
     public bool ComboInput { get; private set; }
 
+    public bool SecondaryActionInput { get; private set; }
+
     public void OnMove(InputAction.CallbackContext context)
     {
         MoveInput = context.ReadValue<Vector2>();
@@ -27,6 +29,21 @@ public class PlayerInputHandler : MonoBehaviour
         if (context.started)
         {
             ComboInput = true;
+        }
+    }
+
+    public void OnSecondaryAction(InputAction.CallbackContext context)
+    {
+        if (context.started)
+        {
+            Debug.Log("SecondaryAction Key started");
+            SecondaryActionInput = true;
+        }
+
+        if (context.canceled)
+        {
+            Debug.Log("SecondaryAction Key canceled");
+            SecondaryActionInput = false;
         }
     }
 

--- a/Moonlighter/Assets/Scripts/Player/Input/PlayerInputHandler.cs
+++ b/Moonlighter/Assets/Scripts/Player/Input/PlayerInputHandler.cs
@@ -36,13 +36,11 @@ public class PlayerInputHandler : MonoBehaviour
     {
         if (context.started)
         {
-            Debug.Log("SecondaryAction Key started");
             SecondaryActionInput = true;
         }
 
         if (context.canceled)
         {
-            Debug.Log("SecondaryAction Key canceled");
             SecondaryActionInput = false;
         }
     }

--- a/Moonlighter/Assets/Scripts/Player/PlayerStates/AbilityState/PlayerAbilityState.cs
+++ b/Moonlighter/Assets/Scripts/Player/PlayerStates/AbilityState/PlayerAbilityState.cs
@@ -22,7 +22,9 @@ public class PlayerAbilityState : PlayerState
     #endregion
 
     #region SecondaryAction Variables
-
+    protected float enoughChargeTime;
+    protected bool isChargeOn = false;
+    protected float checkChargeTime;
 
     #endregion
 
@@ -125,6 +127,22 @@ public class PlayerAbilityState : PlayerState
             {
                 inputHandler.UseComboInput();
             }
+        }
+    }
+
+    #endregion
+
+    #region Player SecondaryAction State Functions
+    protected void CheckEnoughChargeTime()
+    {
+        checkChargeTime += Time.deltaTime;
+        if (checkChargeTime >= enoughChargeTime)
+        {
+            isChargeOn = true;
+        }
+        else
+        {
+            isChargeOn = false;
         }
     }
 

--- a/Moonlighter/Assets/Scripts/Player/PlayerStates/AbilityState/PlayerAbilityState.cs
+++ b/Moonlighter/Assets/Scripts/Player/PlayerStates/AbilityState/PlayerAbilityState.cs
@@ -3,17 +3,28 @@ using UnityEngine;
 
 public class PlayerAbilityState : PlayerState
 {
+    #region Roll Variables
     protected Vector2 rollDir = Vector2.down;
-    protected float checkRollTime;
-    protected float moveX;
-    protected float moveY;
+    private float checkRollTime;
+    private float moveX;
+    private float moveY;
 
-    protected float checkAttackTime;
+    #endregion
+
+    #region ComboAttack Variables
     protected float attackInputDelayTime;
-    protected float attackCorrectionValue = 0.95f;
-    protected float attackInputCorrectionValue = 0.5f;
     protected bool comboAttack;
 
+    private float checkAttackTime;
+    private float attackCorrectionValue = 0.95f;
+    private float attackInputCorrectionValue = 0.4f;
+
+    #endregion
+
+    #region SecondaryAction Variables
+
+
+    #endregion
 
     #region Roll State Functions
 

--- a/Moonlighter/Assets/Scripts/Player/PlayerStates/AbilityState/PlayerComboAttackState/PlayerComboAttackOneState.cs
+++ b/Moonlighter/Assets/Scripts/Player/PlayerStates/AbilityState/PlayerComboAttackState/PlayerComboAttackOneState.cs
@@ -13,6 +13,7 @@ public class PlayerComboAttackOneState : PlayerAbilityState
     override public void OnStateUpdate(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
     {
         base.OnStateUpdate(animator, stateInfo, layerIndex);
+
         LockRoll();
 
         AttackInputDelay(stateInfo);

--- a/Moonlighter/Assets/Scripts/Player/PlayerStates/AbilityState/PlayerComboAttackState/PlayerComboAttackThreeState.cs
+++ b/Moonlighter/Assets/Scripts/Player/PlayerStates/AbilityState/PlayerComboAttackState/PlayerComboAttackThreeState.cs
@@ -6,6 +6,7 @@ public class PlayerComboAttackThreeState : PlayerAbilityState
     override public void OnStateEnter(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
     {
         base.OnStateEnter(animator, stateInfo, layerIndex);
+
         player.CurrentState = PlayerStates.ComboAttackThree;
         rigid.velocity = Vector2.zero;
     }

--- a/Moonlighter/Assets/Scripts/Player/PlayerStates/AbilityState/PlayerSecondaryActionState.meta
+++ b/Moonlighter/Assets/Scripts/Player/PlayerStates/AbilityState/PlayerSecondaryActionState.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 53f7360b2971b08409d3c2d55e05202c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Moonlighter/Assets/Scripts/Player/PlayerStates/AbilityState/PlayerSecondaryActionState/PlayerOnSecondaryActionState.cs
+++ b/Moonlighter/Assets/Scripts/Player/PlayerStates/AbilityState/PlayerSecondaryActionState/PlayerOnSecondaryActionState.cs
@@ -1,0 +1,11 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PlayerOnSecondaryActionState : PlayerAbilityState
+{
+    
+
+
+
+}

--- a/Moonlighter/Assets/Scripts/Player/PlayerStates/AbilityState/PlayerSecondaryActionState/PlayerOnSecondaryActionState.cs
+++ b/Moonlighter/Assets/Scripts/Player/PlayerStates/AbilityState/PlayerSecondaryActionState/PlayerOnSecondaryActionState.cs
@@ -12,6 +12,10 @@ public class PlayerOnSecondaryActionState : PlayerAbilityState
 
     public override void OnStateUpdate(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
     {
+        LockRoll();
+
+        LockAttack();
+
         if (false == inputHandler.SecondaryActionInput)
         {
             ChangeState(animator, PlayerStates.OnSecondaryAction, PlayerAnimParams.ONSECONDARYACTION, PlayerAnimParams.IDLE);

--- a/Moonlighter/Assets/Scripts/Player/PlayerStates/AbilityState/PlayerSecondaryActionState/PlayerOnSecondaryActionState.cs
+++ b/Moonlighter/Assets/Scripts/Player/PlayerStates/AbilityState/PlayerSecondaryActionState/PlayerOnSecondaryActionState.cs
@@ -1,10 +1,27 @@
-using System.Collections;
-using System.Collections.Generic;
+using EnumValue;
 using UnityEngine;
 
 public class PlayerOnSecondaryActionState : PlayerAbilityState
 {
-    
+    public override void OnStateEnter(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
+    {
+        base.OnStateEnter(animator, stateInfo, layerIndex);
+
+        player.CurrentState = PlayerStates.OnSecondaryAction;
+    }
+
+    public override void OnStateUpdate(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
+    {
+        if (false == inputHandler.SecondaryActionInput)
+        {
+            ChangeState(animator, PlayerStates.OnSecondaryAction, PlayerAnimParams.ONSECONDARYACTION, PlayerAnimParams.IDLE);
+        }
+
+        if (inputHandler.MoveInput != Vector2.zero)
+        {
+            ChangeState(animator, PlayerStates.OnSecondaryAction, PlayerAnimParams.ONSECONDARYACTION, PlayerAnimParams.SECONDARYACTION);
+        }
+    }
 
 
 

--- a/Moonlighter/Assets/Scripts/Player/PlayerStates/AbilityState/PlayerSecondaryActionState/PlayerOnSecondaryActionState.cs.meta
+++ b/Moonlighter/Assets/Scripts/Player/PlayerStates/AbilityState/PlayerSecondaryActionState/PlayerOnSecondaryActionState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 229a6e9becbebbe419d100bc051dafed
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Moonlighter/Assets/Scripts/Player/PlayerStates/AbilityState/PlayerSecondaryActionState/PlayerReadySecondaryActionState.cs
+++ b/Moonlighter/Assets/Scripts/Player/PlayerStates/AbilityState/PlayerSecondaryActionState/PlayerReadySecondaryActionState.cs
@@ -1,0 +1,37 @@
+using EnumValue;
+using UnityEngine;
+
+public class PlayerReadySecondaryActionState : PlayerAbilityState
+{
+    private float _enoughChargeTime;
+    private float _checkChargeTime;
+
+    public override void OnStateEnter(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
+    {
+        base.OnStateEnter(animator, stateInfo, layerIndex);
+
+        _enoughChargeTime = stateInfo.length * 0.95f;
+        player.CurrentState = PlayerStates.ReadySecondaryAction;
+    }
+
+    public override void OnStateUpdate(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
+    {
+        base.OnStateUpdate(animator, stateInfo, layerIndex);
+
+        _checkChargeTime += Time.deltaTime;
+
+        if (_checkChargeTime >= _enoughChargeTime)
+        {
+            if (inputHandler.SecondaryActionInput)
+            {
+                _checkChargeTime = 0;
+                ChangeState(animator, PlayerStates.ReadySecondaryAction, PlayerAnimParams.READYSECONDARYACTION, PlayerAnimParams.ONSECONDARYACTION);
+            }
+        }
+
+        if (false == inputHandler.SecondaryActionInput)
+        {
+            ChangeState(animator, PlayerStates.ReadySecondaryAction, PlayerAnimParams.READYSECONDARYACTION, PlayerAnimParams.IDLE);
+        }
+    }
+}

--- a/Moonlighter/Assets/Scripts/Player/PlayerStates/AbilityState/PlayerSecondaryActionState/PlayerReadySecondaryActionState.cs
+++ b/Moonlighter/Assets/Scripts/Player/PlayerStates/AbilityState/PlayerSecondaryActionState/PlayerReadySecondaryActionState.cs
@@ -3,14 +3,11 @@ using UnityEngine;
 
 public class PlayerReadySecondaryActionState : PlayerAbilityState
 {
-    private float _enoughChargeTime;
-    private float _checkChargeTime;
-
     public override void OnStateEnter(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
     {
         base.OnStateEnter(animator, stateInfo, layerIndex);
 
-        _enoughChargeTime = stateInfo.length * 0.95f;
+        enoughChargeTime = stateInfo.length * 0.95f;
         player.CurrentState = PlayerStates.ReadySecondaryAction;
     }
 
@@ -18,13 +15,15 @@ public class PlayerReadySecondaryActionState : PlayerAbilityState
     {
         base.OnStateUpdate(animator, stateInfo, layerIndex);
 
-        _checkChargeTime += Time.deltaTime;
+        LockRoll();
 
-        if (_checkChargeTime >= _enoughChargeTime)
+        LockAttack();
+        CheckEnoughChargeTime();
+        if (isChargeOn)
         {
             if (inputHandler.SecondaryActionInput)
             {
-                _checkChargeTime = 0;
+                checkChargeTime = 0;
                 ChangeState(animator, PlayerStates.ReadySecondaryAction, PlayerAnimParams.READYSECONDARYACTION, PlayerAnimParams.ONSECONDARYACTION);
             }
         }

--- a/Moonlighter/Assets/Scripts/Player/PlayerStates/AbilityState/PlayerSecondaryActionState/PlayerReadySecondaryActionState.cs.meta
+++ b/Moonlighter/Assets/Scripts/Player/PlayerStates/AbilityState/PlayerSecondaryActionState/PlayerReadySecondaryActionState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bcd48fa099bbb9a4abbc285035298c6b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Moonlighter/Assets/Scripts/Player/PlayerStates/AbilityState/PlayerSecondaryActionState/PlayerSecondaryActionState.cs
+++ b/Moonlighter/Assets/Scripts/Player/PlayerStates/AbilityState/PlayerSecondaryActionState/PlayerSecondaryActionState.cs
@@ -1,7 +1,31 @@
-using UnityEngine;
 using EnumValue;
+using UnityEngine;
 
 public class PlayerSecondaryActionState : PlayerAbilityState
 {
-    
+    public override void OnStateEnter(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
+    {
+        base.OnStateEnter(animator, stateInfo, layerIndex);
+
+        player.CurrentState = PlayerStates.SecondaryAction;
+    }
+
+    public override void OnStateUpdate(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
+    {
+        rigid.velocity = inputHandler.MoveInput;
+
+        LockRoll();
+
+        LockAttack();
+
+        if (false == inputHandler.SecondaryActionInput)
+        {
+            ChangeState(animator, PlayerStates.SecondaryAction, PlayerAnimParams.SECONDARYACTION, PlayerAnimParams.IDLE);
+        }
+        
+        if (inputHandler.MoveInput == Vector2.zero)
+        {
+            ChangeState(animator, PlayerStates.SecondaryAction, PlayerAnimParams.SECONDARYACTION, PlayerAnimParams.ONSECONDARYACTION);
+        }
+    }
 }

--- a/Moonlighter/Assets/Scripts/Player/PlayerStates/AbilityState/PlayerSecondaryActionState/PlayerSecondaryActionState.cs
+++ b/Moonlighter/Assets/Scripts/Player/PlayerStates/AbilityState/PlayerSecondaryActionState/PlayerSecondaryActionState.cs
@@ -1,0 +1,8 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PlayerSecondaryActionState : PlayerAbilityState
+{
+    
+}

--- a/Moonlighter/Assets/Scripts/Player/PlayerStates/AbilityState/PlayerSecondaryActionState/PlayerSecondaryActionState.cs
+++ b/Moonlighter/Assets/Scripts/Player/PlayerStates/AbilityState/PlayerSecondaryActionState/PlayerSecondaryActionState.cs
@@ -1,6 +1,5 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
+using EnumValue;
 
 public class PlayerSecondaryActionState : PlayerAbilityState
 {

--- a/Moonlighter/Assets/Scripts/Player/PlayerStates/AbilityState/PlayerSecondaryActionState/PlayerSecondaryActionState.cs.meta
+++ b/Moonlighter/Assets/Scripts/Player/PlayerStates/AbilityState/PlayerSecondaryActionState/PlayerSecondaryActionState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 70daf7764ba91b840bd06a2f6188eb73
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Moonlighter/Assets/Scripts/Player/PlayerStates/GroundedState/PlayerIdleState.cs
+++ b/Moonlighter/Assets/Scripts/Player/PlayerStates/GroundedState/PlayerIdleState.cs
@@ -28,5 +28,9 @@ public class PlayerIdleState : PlayerGroundedState
             inputHandler.UseComboInput();
             ChangeState(animator, PlayerStates.Idle, PlayerAnimParams.IDLE, PlayerAnimParams.COMBOATTACKONE);
         }
+        else if (false == inputHandler.RollInput && false == inputHandler.ComboInput && inputHandler.SecondaryActionInput)
+        {
+            ChangeState(animator, PlayerStates.Idle, PlayerAnimParams.IDLE, PlayerAnimParams.READYSECONDARYACTION);
+        }
     }
 }

--- a/Moonlighter/Assets/Scripts/Player/PlayerStates/PlayerState.cs
+++ b/Moonlighter/Assets/Scripts/Player/PlayerStates/PlayerState.cs
@@ -22,10 +22,10 @@ public class PlayerState : StateMachineBehaviour
 
     #region Player State Functions
 
-    protected void ChangeState(Animator animator, PlayerStates state, string prevState, string newState)
+    protected void ChangeState(Animator animator, PlayerStates state, string currentState, string newState)
     {
         player.PrevState = state;
-        animator.SetBool(prevState, false);
+        animator.SetBool(currentState, false);
         animator.SetBool(newState, true);
     }
 


### PR DESCRIPTION
# PR을 하기 전 체크사항
PR 전에 아래의 내용을 수행했는지 하나씩 체크해봅시다.

<!-- 체크 표시는 []에 x를 넣어 [x]로 만들면 됩니다. 자세한 건 [여기](https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists)를 참고하세요 -->
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능
K키의 입력 여부에 따라 보조 행동을 실행할 수 있습니다.

- K키를 입력하면 보조 공격 차지 상태에 돌입합니다.
- 일정 시간동안 누르고 있으면 차지가 완료됩니다.
- 키를 떼면 보조 공격을 실행합니다.

# 제안 사항
위의 기능을 달성하기 위해 프로젝트에 어떤 변화를 주었는지 작성합니다.

- 보조 공격을 3가지 상태로 분리.
> 처음 키를 입력했을 때 보조 공격 진입 상태와 차지 중인 상태 보조 공격을 실행하는 상태로 나누는게 제일 확장성이 있다고 판단했다.
