### PR TITLE
[Feat] InventoryCursor 구현.

### DIFF
--- a/Moonlighter/Assets/1_Scripts/Player/Input/PlayerInputHandler.cs
+++ b/Moonlighter/Assets/1_Scripts/Player/Input/PlayerInputHandler.cs
@@ -15,12 +15,15 @@ public class PlayerInputHandler : MonoBehaviour
     
     public void OnMove(InputAction.CallbackContext context)
     {
-        MoveInput = context.ReadValue<Vector2>();
+        if(Time.timeScale != 0)
+        {
+            MoveInput = context.ReadValue<Vector2>();
+        }
     }
 
     public void OnRoll(InputAction.CallbackContext context)
     {
-        if (context.started)
+        if (context.started && Time.timeScale != 0)
         {
             RollInput = true;
         }
@@ -28,7 +31,7 @@ public class PlayerInputHandler : MonoBehaviour
 
     public void OnComboAttack(InputAction.CallbackContext context)
     {
-        if (context.started)
+        if (context.started && Time.timeScale != 0)
         {
             ComboInput = true;
             WeaponComboInput = true;
@@ -37,7 +40,7 @@ public class PlayerInputHandler : MonoBehaviour
 
     public void OnSecondaryAction(InputAction.CallbackContext context)
     {
-        if (context.started)
+        if (context.started && Time.timeScale != 0)
         {
             SecondaryActionInput = true;
         }
@@ -50,7 +53,7 @@ public class PlayerInputHandler : MonoBehaviour
 
     public void OnWeaponChange(InputAction.CallbackContext context)
     {
-        if(context.performed)
+        if(context.performed && Time.timeScale != 0)
         {
             WeaponPresenter.ChangeWeapon();
         }

--- a/Moonlighter/Assets/1_Scripts/Presenter/HUDPresenter.cs
+++ b/Moonlighter/Assets/1_Scripts/Presenter/HUDPresenter.cs
@@ -1,7 +1,4 @@
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
 
 public static class HUDPresenter 
 {

--- a/Moonlighter/Assets/1_Scripts/Presenter/InventoryPresenter.cs
+++ b/Moonlighter/Assets/1_Scripts/Presenter/InventoryPresenter.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public static class InventoryPresenter
+{
+    public static event Action OnMoveCursor;
+
+    public static void ModifyCursorPosition()
+    {
+        OnMoveCursor?.Invoke();
+    }
+}

--- a/Moonlighter/Assets/1_Scripts/Presenter/InventoryPresenter.cs.meta
+++ b/Moonlighter/Assets/1_Scripts/Presenter/InventoryPresenter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c87dee6254f13ec48b86ca6e45f60aeb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Moonlighter/Assets/1_Scripts/UI/CursorController.cs
+++ b/Moonlighter/Assets/1_Scripts/UI/CursorController.cs
@@ -1,11 +1,15 @@
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.UI;
 
 public class CursorController : MonoBehaviour
 {
-    public RectTransform StartPos;
+    public RectTransform[][] InventorySlot;
+
+    public UIInputHandler UIInputHandler { get; private set; }
+
+    private int _xPos;
+    private int _yPos;
 
     [SerializeField]
     public RectTransform[] FirstLineSlotPos;
@@ -13,15 +17,129 @@ public class CursorController : MonoBehaviour
     public RectTransform[] ThirdLineSlotPos;
     public RectTransform[] FourthLineSlotPos;
 
-    // Start is called before the first frame update
-    void Start()
+    public GridLayoutGroup PlayerBelonging;
+    public GridLayoutGroup InBag;
+
+    private void Awake()
     {
-        
+        InventorySlot = new RectTransform[4][];
+        InventorySlot[0] = FirstLineSlotPos;
+        InventorySlot[1] = SecondLineSlotPos;
+        InventorySlot[2] = ThirdLineSlotPos;
+        InventorySlot[3] = FourthLineSlotPos;
+
+        UIInputHandler = transform.root.GetComponent<UIInputHandler>();
+
     }
 
-    // Update is called once per frame
-    void Update()
+    private void OnEnable()
     {
-        
+        InventoryPresenter.OnMoveCursor -= MoveCursor;
+        InventoryPresenter.OnMoveCursor += MoveCursor;
+        SetDefaultPosition();
+    }
+
+    public void SetDefaultPosition()
+    {
+        _xPos = 0;
+        _yPos = 0;
+        transform.SetParent(InventorySlot[_yPos][_xPos]);
+        transform.position = transform.parent.position;
+    }
+
+    public void MoveCursor()
+    {
+        if(UIInputHandler.CursorInput.x != 0 && UIInputHandler.CursorInput.y > 0)
+        {
+            if((_yPos == 0 || _yPos == 2) && _xPos == 6)
+            {
+                _xPos = 5;
+            }
+
+            --_yPos;
+
+            if(_yPos < 0)
+            {
+                _yPos = 3;
+            }
+        }
+        else if(UIInputHandler.CursorInput.x != 0 && UIInputHandler.CursorInput.y < 0)
+        {
+            if((_yPos == 0 || _yPos == 2) && _xPos == 6)
+            {
+                _xPos = 5;
+            }
+
+            ++_yPos;
+
+            if(_yPos > 3)
+            {
+                _yPos = 0;
+            }
+
+        }
+        else if(UIInputHandler.CursorInput.x == 0 && UIInputHandler.CursorInput.y == 1)
+        {
+            if ((_yPos == 0 || _yPos == 2) && _xPos == 6)
+            {
+                _xPos = 5;
+            }
+
+            --_yPos;
+
+            if(_yPos < 0)
+            {
+                _yPos = 3;
+            }
+        }
+        else if(UIInputHandler.CursorInput.x == 0 && UIInputHandler.CursorInput.y == -1)
+        {
+            if ((_yPos == 0 || _yPos == 2) && _xPos == 6)
+            {
+                _xPos = 5;
+            }
+
+            ++_yPos;
+
+            if(_yPos > 3)
+            {
+                _yPos = 0;
+            }
+        }
+        else if(UIInputHandler.CursorInput.x == -1 && UIInputHandler.CursorInput.y == 0)
+        {
+            --_xPos;
+            if(_xPos < 0)
+            {
+                if(_yPos == 0 || _yPos == 2)
+                {
+                    _xPos = 6;
+                }
+                else
+                {
+                    _xPos = 5;
+                }
+            }
+        }
+        else if(UIInputHandler.CursorInput.x == 1 && UIInputHandler.CursorInput.y == 0)
+        {
+            ++_xPos;
+            if(_yPos == 0 || _yPos == 2)
+            {
+                if(_xPos > 6)
+                {
+                    _xPos = 0;
+                }
+            }
+            else
+            {
+                if(_xPos > 5)
+                {
+                    _xPos = 0;
+                }
+            }
+        }
+        transform.SetParent(InventorySlot[_yPos][_xPos]);
+        transform.position = transform.parent.position;
     }
 }

--- a/Moonlighter/Assets/1_Scripts/UI/HUDController.cs
+++ b/Moonlighter/Assets/1_Scripts/UI/HUDController.cs
@@ -5,6 +5,8 @@ public class HUDController : MonoBehaviour
 {
     private UIInputHandler _uiInputHandler;
 
+    public CursorController Cursor;
+
     #region Inventory 관련 변수들
     public RectTransform InventoryIcon;
     public RectTransform InventoryAndStatusWindow;
@@ -30,6 +32,8 @@ public class HUDController : MonoBehaviour
 
     private void Awake()
     {
+        DontDestroyOnLoad(this);
+
         _uiInputHandler = GetComponent<UIInputHandler>();
 
         _inventoryIconInPosition = InventoryIcon.position;
@@ -100,7 +104,7 @@ public class HUDController : MonoBehaviour
             _isFading = true;
             while (elapsedTime / _iconFadeTime < 1.0f)
             {
-                elapsedTime += Time.deltaTime;
+                elapsedTime += Time.unscaledDeltaTime;
                 InventoryIcon.position = Vector3.Lerp(InventoryIcon.position, _inventoryIconInPosition,
                     elapsedTime / _iconFadeTime);
                 yield return null;
@@ -119,7 +123,7 @@ public class HUDController : MonoBehaviour
             _isFading = true;
             while (elapsedTime / _iconFadeTime < 1.0f)
             {
-                elapsedTime += Time.deltaTime;
+                elapsedTime += Time.unscaledDeltaTime;
                 InventoryIcon.position = Vector3.Lerp(InventoryIcon.position, _inventoryIconOutPosition,
                     elapsedTime / _iconFadeTime);
                 yield return null;
@@ -134,15 +138,17 @@ public class HUDController : MonoBehaviour
     {
         while (true)
         {
+            Cursor.gameObject.SetActive(true);
             float elapsedTime = 0f;
             _isFading = true;
             while (elapsedTime / _windowFadeTime < 1.0f)
             {
-                elapsedTime += Time.deltaTime;
+                elapsedTime += Time.unscaledDeltaTime;
                 InventoryAndStatusWindow.position = Vector3.Lerp(InventoryAndStatusWindow.position, _inventoryAndStatusWindowInPosition, elapsedTime / _windowFadeTime);
                 yield return null;
             }
             _isFading = false;
+            Time.timeScale = 0f;
             StopCoroutine(_fadeInWindow);
             yield return null;
         }
@@ -156,11 +162,13 @@ public class HUDController : MonoBehaviour
             _isFading = true;
             while (elapsedTime / _windowFadeTime < 1.0f)
             {
-                elapsedTime += Time.deltaTime;
+                elapsedTime += Time.unscaledDeltaTime;
                 InventoryAndStatusWindow.position = Vector3.Lerp(InventoryAndStatusWindow.position, _inventoryAndStatusWindowOutPosition, elapsedTime / _windowFadeTime);
                 yield return null;
             }
             _isFading = false;
+            Time.timeScale = 1f;
+            Cursor.gameObject.SetActive(false);
             StopCoroutine(_fadeOutWindow);
             yield return null;
         }

--- a/Moonlighter/Assets/1_Scripts/UI/UIInputHandler.cs
+++ b/Moonlighter/Assets/1_Scripts/UI/UIInputHandler.cs
@@ -20,7 +20,14 @@ public class UIInputHandler : MonoBehaviour
 
     public void OnCursorMove(InputAction.CallbackContext context)
     {
-        CursorInput = context.ReadValue<Vector2>();
+        if(Time.timeScale == 0f)
+        {
+            if(context.performed)
+            {
+                CursorInput = context.ReadValue<Vector2>();
+                InventoryPresenter.ModifyCursorPosition();
+            }
+        }
     }
 
 

--- a/Moonlighter/Assets/6_Scenes/SampleScene.unity
+++ b/Moonlighter/Assets/6_Scenes/SampleScene.unity
@@ -778,7 +778,7 @@ GameObject:
   - component: {fileID: 102800276}
   - component: {fileID: 102800275}
   m_Layer: 5
-  m_Name: Weapon
+  m_Name: PotionBase
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1006,7 +1006,7 @@ GameObject:
   - component: {fileID: 147728183}
   - component: {fileID: 147728182}
   m_Layer: 5
-  m_Name: Weapon
+  m_Name: NoneSlot
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1801,7 +1801,7 @@ GameObject:
   - component: {fileID: 392210835}
   - component: {fileID: 392210834}
   m_Layer: 5
-  m_Name: Weapon
+  m_Name: NoneSlot
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -2994,6 +2994,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: cca3f7a81689626469dd367f6d9f46c4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  Cursor: {fileID: 1418228782}
   InventoryIcon: {fileID: 1332910163}
   InventoryAndStatusWindow: {fileID: 1212048201}
 --- !u!114 &673325989
@@ -3058,7 +3059,19 @@ MonoBehaviour:
     m_ActionId: 123a8525-21e7-4694-80dc-b0ad8d9c0cda
     m_ActionName: UI/InventoryKey[/Keyboard/i]
   - m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 673325986}
+        m_TargetAssemblyTypeName: UIInputHandler, Assembly-CSharp
+        m_MethodName: OnCursorMove
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
     m_ActionId: 21595056-abc5-440b-943c-21d0a71da134
     m_ActionName: UI/CursorMove[/Keyboard/w,/Keyboard/s,/Keyboard/a,/Keyboard/d]
   m_NeverAutoSwitchControlSchemes: 0
@@ -5108,7 +5121,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1418228779
 RectTransform:
   m_ObjectHideFlags: 0
@@ -5116,7 +5129,7 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1418228778}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -5124,10 +5137,10 @@ RectTransform:
   m_Father: {fileID: 1409243404}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -572, y: 242.1}
-  m_SizeDelta: {x: -1400, y: -702}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -259, y: 242.5}
+  m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1418228780
 MonoBehaviour:
@@ -5223,37 +5236,38 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 89120b4fbd190614c8df64a266dbdc11, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  StartPos: {fileID: 657765499}
   FirstLineSlotPos:
   - {fileID: 657765499}
   - {fileID: 2081839201}
   - {fileID: 1861604662}
   - {fileID: 2030432848}
   - {fileID: 866978435}
-  - {fileID: 1848645432}
-  - {fileID: 875069969}
+  - {fileID: 920021784}
+  - {fileID: 1835333332}
   SecondLineSlotPos:
   - {fileID: 294431646}
   - {fileID: 1912830755}
   - {fileID: 2011051661}
   - {fileID: 1832169774}
   - {fileID: 364829262}
-  - {fileID: 28799919}
+  - {fileID: 392210833}
   ThirdLineSlotPos:
   - {fileID: 310573919}
   - {fileID: 48431726}
   - {fileID: 464288717}
   - {fileID: 1765658828}
   - {fileID: 24260712}
-  - {fileID: 198437834}
-  - {fileID: 406861428}
+  - {fileID: 147728181}
+  - {fileID: 102800274}
   FourthLineSlotPos:
   - {fileID: 909507689}
   - {fileID: 353168870}
   - {fileID: 123596614}
   - {fileID: 778248820}
   - {fileID: 437727670}
-  - {fileID: 1212924236}
+  - {fileID: 1879934048}
+  PlayerBelonging: {fileID: 1272569022}
+  InBag: {fileID: 1693580199}
 --- !u!114 &1418228783
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -7214,7 +7228,7 @@ GameObject:
   - component: {fileID: 1879934050}
   - component: {fileID: 1879934049}
   m_Layer: 5
-  m_Name: Weapon
+  m_Name: NoneSlot
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0

--- a/Moonlighter/Assets/7_InputActions/PlayerInput.inputactions
+++ b/Moonlighter/Assets/7_InputActions/PlayerInput.inputactions
@@ -190,7 +190,7 @@
                 },
                 {
                     "name": "2D Vector",
-                    "id": "a776d052-e073-4dea-b100-c7d1e9798e48",
+                    "id": "cd14738a-24cb-49ec-8fa1-1fa54eb92142",
                     "path": "2DVector",
                     "interactions": "",
                     "processors": "",
@@ -201,7 +201,7 @@
                 },
                 {
                     "name": "up",
-                    "id": "9efe3955-3c58-405a-bd69-7416f790855a",
+                    "id": "835f5d57-bd35-488d-b614-39404d6fc29e",
                     "path": "<Keyboard>/w",
                     "interactions": "",
                     "processors": "",
@@ -212,7 +212,7 @@
                 },
                 {
                     "name": "down",
-                    "id": "bcbf3682-3987-40c1-a7d0-3338db7508b4",
+                    "id": "6a126f60-7a74-4e65-96cf-5b0ea117f59e",
                     "path": "<Keyboard>/s",
                     "interactions": "",
                     "processors": "",
@@ -223,7 +223,7 @@
                 },
                 {
                     "name": "left",
-                    "id": "de123405-ac40-4f9a-82ba-6cbb656bf087",
+                    "id": "9b817ddb-6eef-4016-af4f-46c2a19f5fde",
                     "path": "<Keyboard>/a",
                     "interactions": "",
                     "processors": "",
@@ -234,7 +234,7 @@
                 },
                 {
                     "name": "right",
-                    "id": "679d3b34-17d9-4f5d-9b04-a4e2bcac50a5",
+                    "id": "5ca23a4c-4079-4486-ba73-a704db11d68d",
                     "path": "<Keyboard>/d",
                     "interactions": "",
                     "processors": "",


### PR DESCRIPTION
# PR을 하기 전 체크사항
PR 전에 아래의 내용을 수행했는지 하나씩 체크해봅시다.

<!-- 체크 표시는 []에 x를 넣어 [x]로 만들면 됩니다. 자세한 건 [여기](https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists)를 참고하세요 -->
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능

- 인벤토리창을 열었을 때 게임을 일시정지시킴.
- 인벤토리창을 열었을 때 인벤토리창에 커서가 생기고  키보드입력으로 이동시킬 수 있음.

# 제안 사항

- 인벤토리창과 아이콘이 이동하는 코루틴 함수에 deltaTime이 아닌 unscaledDeltaTime을 사용함.
> deltaTime을 사용하면 일시정지했을 때 UI가 움직이지 않는다.
- UI Action map에 커서이동키를 추가.
> 커서이동하기 위해.
- InventoryPresenter 생성.
> 플레이어의 인풋과 커서사이에 메시지를 주고받기 위해.

# 스크린샷

https://user-images.githubusercontent.com/72890183/234785361-1d0103a9-d751-4f29-a0cb-4a45ab04769a.mp4


